### PR TITLE
Update start_local.sh

### DIFF
--- a/app/start_local.sh
+++ b/app/start_local.sh
@@ -15,9 +15,12 @@ if ! [ -x "$(command -v docker)" ]; then
 fi
 
 if ! [ -x "$(command -v docker-compose)" ]; then
-    echo 'Error: docker-compose is not installed.' >&2
-    echo 'Please install docker-compose before running this setup script.' >&2
-    exit 1
+    docker compose 2>&1 > /dev/null
+    if [[ $? -ne 0 ]]; then
+        echo 'Error: docker-compose is not installed.' >&2
+        echo 'Please install docker-compose before running this setup script.' >&2
+        exit 1
+    fi
 fi
 
 # make sure that we are in the same directory as the script


### PR DESCRIPTION
### **User description**
**Notes for Reviewers**

This PR fixes #




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [*] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the `start_local.sh` script by adding a check for the `docker compose` command.
- Improved error handling to ensure `docker-compose` is installed before proceeding.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>start_local.sh</strong><dd><code>Enhance docker-compose installation check with additional validation</code></dd></summary>
<hr>

app/start_local.sh

<li>Added a check for <code>docker compose</code> command availability.<br> <li> Improved error handling for <code>docker-compose</code> installation check.<br>


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/gpt4cli/pull/11/files#diff-fb00ac39add9f847122854afdab47675e234ee1a355b44a53a1c3726c205a16c">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for `docker-compose` dependency check in the local start script, providing clearer instructions for users if the tool is not installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->